### PR TITLE
feat: Implement favorites functionality

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -15,19 +15,10 @@ migration:
     - platform: root
       create_revision: edada7c56edf4a183c1735310e123c7f923584f1
       base_revision: edada7c56edf4a183c1735310e123c7f923584f1
-    - platform: android
-      create_revision: edada7c56edf4a183c1735310e123c7f923584f1
-      base_revision: edada7c56edf4a183c1735310e123c7f923584f1
-    - platform: ios
-      create_revision: edada7c56edf4a183c1735310e123c7f923584f1
-      base_revision: edada7c56edf4a183c1735310e123c7f923584f1
     - platform: linux
       create_revision: edada7c56edf4a183c1735310e123c7f923584f1
       base_revision: edada7c56edf4a183c1735310e123c7f923584f1
     - platform: macos
-      create_revision: edada7c56edf4a183c1735310e123c7f923584f1
-      base_revision: edada7c56edf4a183c1735310e123c7f923584f1
-    - platform: web
       create_revision: edada7c56edf4a183c1735310e123c7f923584f1
       base_revision: edada7c56edf4a183c1735310e123c7f923584f1
     - platform: windows

--- a/lib/favorites_page.dart
+++ b/lib/favorites_page.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:pokedex/models/pokemonModel.dart';
+import 'package:pokedex/pokemonDetailPage.dart';
+import 'package:pokedex/providers/favorites_provider.dart';
+import 'package:provider/provider.dart';
+
+class FavoritesPage extends StatelessWidget {
+  const FavoritesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Meus Favoritos'),
+      ),
+      body: Consumer<FavoritesProvider>(
+        builder: (context, favoritesProvider, child) {
+          final favorites = favoritesProvider.favorites;
+
+          // Verifica se a lista de favoritos está vazia
+          if (favorites.isEmpty) {
+            return const Center(
+              child: Text(
+                'Você ainda não favoritou nenhum Pokémon.',
+                style: TextStyle(fontSize: 18),
+                textAlign: TextAlign.center,
+              ),
+            );
+          }
+
+          // Se não estiver vazia, exibe a lista de Pokémon
+          return ListView.builder(
+            itemCount: favorites.length,
+            itemBuilder: (context, index) {
+              final pokemon = favorites[index];
+              return ListTile(
+                // Exibe a imagem do Pokémon
+                leading: Image.network(
+                  pokemon.sprites.front_default ?? '',
+                  // Adiciona um placeholder em caso de erro na imagem
+                  errorBuilder: (context, error, stackTrace) {
+                    return const Icon(Icons.error);
+                  },
+                ),
+                title: Text(pokemon.name.toUpperCase()),
+                subtitle: Text('#${pokemon.id.toString().padLeft(3, '0')}'),
+                onTap: () {
+                  // Ao tocar, navega para a tela de detalhes
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => PokemonDetailPage(
+                        // Precisamos passar um PokemonListResult, então criamos um
+                        pokemonInfo: PokemonListResult(Name: pokemon.name, Url: ''),
+                      ),
+                    ),
+                  );
+                },
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/homepage.dart
+++ b/lib/homepage.dart
@@ -5,6 +5,7 @@ import 'package:pokedex/main.dart';
 import 'package:http/http.dart' as http;
 import 'package:pokedex/models/pokemonModel.dart';
 import 'package:pokedex/pokemonDetailPage.dart';
+import 'package:pokedex/favorites_page.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -51,7 +52,7 @@ class _HomePageState extends State<HomePage> {
                 "Pokedex App",
                 style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
-              SizedBox(height: 16), // Adding spacing between elements
+              SizedBox(height: 16),
               Row(
                 children: [
                   Expanded(
@@ -63,14 +64,24 @@ class _HomePageState extends State<HomePage> {
                     ),
                   ),
 
-                  SizedBox(width: 8), // Adding spacing between elements
+                  SizedBox(width: 8),
 
                   IconButton(icon: Icon(Icons.search), onPressed: () {}),
                 ],
               ),
 
-              SizedBox(height: 16), // Adding spacing between elements
-
+              SizedBox(height: 16),
+              ElevatedButton.icon(
+                icon: Icon(Icons.favorite),
+                label: Text("Ver Favoritos"),
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) => FavoritesPage()),
+                  );
+                },
+              ),
+              SizedBox(height: 16),
               Expanded(
                 child: ListView.builder(
                   itemCount: pokemonList.length,
@@ -88,7 +99,7 @@ class _HomePageState extends State<HomePage> {
                       child: Padding(
                         padding: EdgeInsets.all(8.0),
                         child: Text(
-                          pokemon.Name, // use lowerCamelCase if it's a Dart field
+                          pokemon.Name,
                           style: TextStyle(fontSize: 18),
                         ),
                       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:pokedex/homepage.dart';
+import 'package:pokedex/providers/favorites_provider.dart';
+import 'package:provider/provider.dart';
 
 const api = "https://pokeapi.co/api/v2/";
 
 void main() {
-  runApp(const MainApp());
+  runApp(
+    ChangeNotifierProvider(
+      create: (context) => FavoritesProvider(), // Cria uma instância do nosso provider
+      child: const MainApp(), // O nosso app original se torna filho do provider
+    ),
+  );
 }
 
 class MainApp extends StatelessWidget {
@@ -16,6 +23,8 @@ class MainApp extends StatelessWidget {
       home: Scaffold(
         body: HomePage(),
       ),
+      debugShowCheckedModeBanner: false, // remove o banner de debug
     );
   }
 }
+

--- a/lib/pokemonDetailPage.dart
+++ b/lib/pokemonDetailPage.dart
@@ -1,9 +1,10 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:pokedex/homepage.dart';
 import 'package:pokedex/main.dart';
 import 'package:pokedex/models/pokemonModel.dart';
+import 'package:provider/provider.dart';
+import 'package:pokedex/providers/favorites_provider.dart';
 
 import 'package:http/http.dart' as http;
 
@@ -19,62 +20,99 @@ class _PokemonDetailPageState extends State<PokemonDetailPage> {
   Pokemon? pokemon;
 
   void fetchPokemon() async {
-    final url = Uri.parse(api + 'pokemon/' + widget.pokemonInfo.Name);
+    final url = Uri.parse(api + 'pokemon/' + widget.pokemonInfo.Name.toLowerCase());
     final response = await http.get(url);
 
     if (response.statusCode == 200) {
       final data = jsonDecode(response.body);
-      setState(() {
-        pokemon = Pokemon.fromJson(data);
-      });
+      // Garante que o widget ainda está na árvore de widgets antes de atualizar o estado
+      if (mounted) {
+        setState(() {
+          pokemon = Pokemon.fromJson(data);
+        });
+      }
     } else {
-      throw Exception('Failed to load Pokemon');
+      debugPrint('Falha ao carregar o Pokémon: ${response.statusCode}');
     }
   }
 
   @override
   void initState() {
     super.initState();
-
     fetchPokemon();
   }
 
+  @override
   Widget build(BuildContext context) {
+    final favoritesProvider = Provider.of<FavoritesProvider>(context);
+
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.pokemonInfo.Name.toUpperCase()),
+        // 2. A propriedade 'actions' é onde adicionamos botões à direita na AppBar.
+        actions: [
+          if (pokemon != null)
+            Consumer<FavoritesProvider>(
+              builder: (context, favoritesProvider, child) {
+                final isFav = favoritesProvider.isFavorite(pokemon!);
+                return IconButton(
+                  icon: Icon(
+                    isFav ? Icons.star : Icons.star_border,
+                    color: isFav ? Colors.amber : Colors.blueAccent,
+                    size: 30,
+                  ),
+                  onPressed: () {
+                    favoritesProvider.toggleFavorite(pokemon!);
+                  },
+                );
+              },
+            )
+        ],
       ),
       body: Center(
+        // Enquanto 'pokemon' for nulo, exibe um indicador de carregamento.
         child: pokemon == null
             ? const CircularProgressIndicator()
-            : Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Image.network(pokemon!.sprites.front_default!),
-                  Text(
-                    pokemon!.name.toUpperCase(),
-                    style: const TextStyle(
-                        fontSize: 24, fontWeight: FontWeight.bold),
-                  ),
-                  const SizedBox(height: 16),
-                  Text("Height: ${pokemon!.height}"),
-                  Text("Weight: ${pokemon!.weight}"),
-                  const SizedBox(height: 16),
-                  const Text(
-                    "Types:",
-                    style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-                  ),
-                  Wrap(
-                    spacing: 8.0,
-                    children: pokemon!.types
-                        .map((typeInfo) => Chip(
-                              label: Text(typeInfo.type.name),
-                            ))
-                        .toList(),
-                  ),
-                ],
+            : SingleChildScrollView( // Adicionado para evitar overflow em telas pequenas
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Image.network(
+                pokemon!.sprites.front_default ?? '',
+                height: 200,
+                fit: BoxFit.cover,
+                errorBuilder: (context, error, stackTrace) {
+                  return const Icon(Icons.error, size: 100);
+                },
               ),
+              const SizedBox(height: 16),
+              Text(
+                pokemon!.name.toUpperCase(),
+                style: const TextStyle(
+                    fontSize: 24, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 16),
+              Text("Altura: ${pokemon!.height / 10} m"),
+              Text("Peso: ${pokemon!.weight / 10} kg"),
+              const SizedBox(height: 16),
+              const Text(
+                "Tipos:",
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              ),
+              Wrap(
+                spacing: 8.0,
+                children: pokemon!.types
+                    .map((typeInfo) => Chip(
+                  label: Text(typeInfo.type.name),
+                ))
+                    .toList(),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }
 }
+

--- a/lib/providers/favorites_provider.dart
+++ b/lib/providers/favorites_provider.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:pokedex/models/pokemonModel.dart';
+
+class FavoritesProvider extends ChangeNotifier {
+  final List<Pokemon> _favorites = [];
+
+  List<Pokemon> get favorites => _favorites;
+
+  bool isFavorite(Pokemon pokemon) {
+    return _favorites.any((p) => p.id == pokemon.id);
+  }
+
+  void toggleFavorite(Pokemon pokemon) {
+    if (isFavorite(pokemon)) {
+      _favorites.removeWhere((p) => p.id == pokemon.id);
+    } else {
+      _favorites.add(pokemon);
+    }
+    notifyListeners();
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -139,6 +139,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -147,6 +155,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5+1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^1.5.0
+  provider: ^6.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This commit introduces the ability for users to mark and view their favorite Pokémon.

Key changes include:
- Added a "Ver Favoritos" (View Favorites) button on the HomePage.
- Created a new `FavoritesPage` to display the list of favorited Pokémon.
- Implemented `FavoritesProvider` using the `provider` package for state management of favorites.
- Added a star icon on the `PokemonDetailPage` to toggle a Pokémon's favorite status.
- Updated `pubspec.yaml` to include the `provider` dependency.
- Made minor UI adjustments and improvements in `HomePage` and `PokemonDetailPage`.
- Renamed `favoritespage.dart` to `favorites_page.dart` for consistency.
- Updated `.metadata` to reflect changes in supported platforms.